### PR TITLE
fix prek

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
       - run: uv sync --all-extras
       - name: prek check
         uses: j178/prek-action@v1
+        env:
+          SKIP: no-commit-to-branch
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This keeps the local protection intact (you still can't accidentally commit straight to main on your machine) while letting the post-merge CI run pass.

Note: PR-triggered runs usually pass anyway because they run on a detached merge ref, not literally main. It's the push to main after merging that was failing, which matches what you described.