### PR TITLE
Fix merge-time docs deploy cancellation + restore prune workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,9 +12,12 @@ on:
 permissions:
   contents: read
 
-# Serialize writes to gh-pages so jobs never race the branch.
+# Scope concurrency per PR (and per branch for pushes) so the production deploy
+# on a merge's push event is never cancelled by the same PR's "closed" run.
+# Both deploy actions retry on a rejected push, so this won't cause gh-pages
+# races. cancel-in-progress stays false so an in-flight publish always finishes.
 concurrency:
-  group: gh-pages-deploy
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/prune-deployments.yml
+++ b/.github/workflows/prune-deployments.yml
@@ -1,0 +1,49 @@
+name: prune-deployments
+
+# GitHub creates a `github-pages` deployment record on every push to the
+# gh-pages branch (each PR preview and each production publish), and never
+# deletes them. This workflow prunes the old ones, keeping the most recent few.
+
+on:
+  schedule:
+    - cron: "0 4 * * 1" # weekly, Monday 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  deployments: write
+
+concurrency:
+  group: prune-deployments
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete stale github-pages deployments
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          KEEP: "10" # number of most-recent deployments to retain
+        run: |
+          set -euo pipefail
+          ids=$(gh api --paginate \
+            "repos/$REPO/deployments?environment=github-pages&per_page=100" \
+            --jq '.[].id' | sort -rn)
+          n=0
+          while read -r id; do
+            [ -z "$id" ] && continue
+            n=$((n + 1))
+            if [ "$n" -le "$KEEP" ]; then
+              continue
+            fi
+            # A deployment must be inactive before it can be deleted.
+            gh api -X POST "repos/$REPO/deployments/$id/statuses" \
+              -f state=inactive >/dev/null 2>&1 || true
+            if gh api -X DELETE "repos/$REPO/deployments/$id" >/dev/null 2>&1; then
+              echo "deleted deployment $id"
+            else
+              echo "could not delete $id (skipped)"
+            fi
+          done <<< "$ids"
+          echo "Kept the $KEEP most recent github-pages deployments."


### PR DESCRIPTION
Follow-up to #15. Two issues:

### 1. Production deploy gets cancelled on merge (site is 404)
Merging a PR fires two `docs` runs simultaneously: the `push` to `main` (which runs `deploy-main`) and the `pull_request: closed` run (cleanup). They shared one global `concurrency` group (`gh-pages-deploy`), so GitHub cancelled the pending push run and `deploy-main` never published — the production site stayed 404. This would recur on every merge.

**Fix:** scope the concurrency group per PR / per branch:
```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
```
Now the main-branch deploy runs in its own group, independent of PR events. Both `JamesIves/github-pages-deploy-action` and `rossjrw/pr-preview-action` retry on a rejected push, so concurrent gh-pages writes still won't corrupt the branch.

### 2. Restore `prune-deployments.yml`
This workflow (prunes old `github-pages` deployment records) did not make it into the #15 squash merge, so it's missing from `main`. Re-added unchanged. No other workflows are touched.

After merge, the push to `main` will run `deploy-main` and publish to the `gh-pages` root, bringing `https://juanitorduz.github.io/numpyro_forecast/` live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)