### PR TITLE
Add .nojekyll so notebook figures load on GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,6 +58,11 @@ jobs:
         with:
           name: docs-site
           path: great-docs/_site
+      # GitHub Pages runs Jekyll on branch deploys, which drops files whose
+      # names start with "_" (e.g. the embedded-notebook figures named
+      # _src-*.png). .nojekyll at the site root disables Jekyll branch-wide.
+      - name: Disable Jekyll
+        run: touch great-docs/_site/.nojekyll
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages


### PR DESCRIPTION
### Problem
The docs site is live but every example-notebook plot is a broken image.

**Root cause:** we deploy docs via the `gh-pages` *branch*, and GitHub Pages runs **Jekyll** on branch deploys. Jekyll silently drops files whose names start with `_`. The embedded-notebook figures are named `forecasting_univariate_files/figure-html/_src-*.png` (the `_src-` prefix comes from the `_src/` embed-staging dir), so the files are committed to `gh-pages` but 404 when served. The page HTML loads because `site_libs/` has no underscore.

### Fix
Write a `.nojekyll` marker into the site root on `deploy-main`, which disables Jekyll for the whole branch — so all `_`-prefixed assets (the figures, `_extensions/`, etc.) serve verbatim, for both production and PR previews. `.nojekyll` lives in the published `_site`, so it survives `deploy-main`'s `clean: true`.

A `.nojekyll` was also added to the live `gh-pages` root out-of-band to restore production immediately; this PR makes it persist across future deploys.

No workflows removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)