### PR TITLE
Add coverage configuration to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,5 +129,16 @@ addopts = [
     "--color=yes",
 ]
 
+[tool.coverage.run]
+source = ["numpyro_forecast"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+]
+
 [tool.ty.environment]
 python-version = "3.12"


### PR DESCRIPTION
Add `[tool.coverage.run]` and `[tool.coverage.report]` sections to `pyproject.toml`, complementing the existing `--cov` flags in pytest addopts.

Closes #22

Generated with [Claude Code](https://claude.ai/code)